### PR TITLE
Basic transport doesn't support errback

### DIFF
--- a/nsone/rest/transport/basic.py
+++ b/nsone/rest/transport/basic.py
@@ -35,6 +35,10 @@ class BasicTransport(TransportBase):
         request.get_method = lambda: method
 
         def handleProblem(code, resp, msg):
+            if errback:
+                errback(resp)
+                return
+
             if code == 429:
                 raise RateLimitException('rate limit exceeded',
                                          resp,


### PR DESCRIPTION
When using the basic transport errback is never called when status code isn't 200. This forces you use a try and its confusing that the function parameter doesn't work as expected.
