### PR TITLE
Fixed issue in Zone.add_*

### DIFF
--- a/nsone/zones.py
+++ b/nsone/zones.py
@@ -123,7 +123,7 @@ class Zone(object):
             raise AttributeError(item)
 
         # dynamic adding of various record types, e.g. add_A, add_CNAME, etc
-        (_, rtype) = item.split('_', 2)
+        (_, rtype) = item.split('_', 1)
 
         def add_X(domain, answers, callback=None, errback=None, **kwargs):
             kwargs['answers'] = answers


### PR DESCRIPTION
split('_', 2) could return 3 items which would cause a ValueError exception.
