### PR TITLE
Fix feed deletion URL

### DIFF
--- a/nsone/rest/data.py
+++ b/nsone/rest/data.py
@@ -100,8 +100,8 @@ class Feed(resource.BaseResource):
                                   callback=callback,
                                   errback=errback)
 
-    def delete(self, feedid, callback=None, errback=None):
+    def delete(self, sourceid, feedid, callback=None, errback=None):
         return self._make_request('DELETE',
-                                  '%s/%s' % (self.ROOT, feedid),
+                                  '%s/%s/%s' % (self.ROOT, sourceid, feedid),
                                   callback=callback,
                                   errback=errback)


### PR DESCRIPTION
API endpoint for feed deletion require sourceid.
`/data/feeds/:sourceid/:feedid`, see https://ns1.com/api/
