### PR TITLE
use six.string_types for py2/py3 compat

### DIFF
--- a/nsone/rest/records.py
+++ b/nsone/rest/records.py
@@ -3,9 +3,13 @@
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 
+import sys
 import collections
 
 from . import resource
+
+
+py_str = str if sys.version_info[0] == 3 else basestring
 
 
 class Records(resource.BaseResource):
@@ -33,7 +37,7 @@ class Records(resource.BaseResource):
     def _getAnswersForBody(self, answers):
         realAnswers = []
         # simplest: they specify a single string ip
-        if isinstance(answers, basestring):
+        if isinstance(answers, py_str):
             answers = [answers]
         # otherwise, we need an iterable
         elif not isinstance(answers, collections.Iterable):
@@ -41,7 +45,7 @@ class Records(resource.BaseResource):
         # at this point we have a list. loop through and build out the answer
         # entries depending on contents
         for a in answers:
-            if isinstance(a, basestring):
+            if isinstance(a, py_str):
                 realAnswers.append({'answer': [a]})
             elif isinstance(a, (list, tuple)):
                 realAnswers.append({'answer': a})


### PR DESCRIPTION
I just hit this with Python 3.5 six is being installed during py27 testing of tox but it isn't declared as an install_dependency. I also had the following code:

``` python
import sys

py_str = str if sys.version_info[0] == 3 else basestring
```

but it'd be cleaner to use six. fixes #13
