### PR TITLE
Handle domains that end with the parent zone, but in the middle of a label.

### DIFF
--- a/nsone/records.py
+++ b/nsone/records.py
@@ -29,8 +29,14 @@ class Record(object):
         """
         self._rest = Records(parentZone.config)
         self.parentZone = parentZone
-        if not domain.endswith(parentZone.zone):
-            domain = domain + '.' + parentZone.zone
+        zone = parentZone.zone
+        if not (
+            # The domain ends with the parent zone
+            domain.endswith(zone)
+            # and is on a label boundary
+            and domain[1-len(zone):-len(zone)] in ('', '.')
+        ):
+            domain = domain + '.' + zone
         self.domain = domain
         self.type = type
         self.data = None


### PR DESCRIPTION
There aren't any tests for this module, so I didn't add any for this behavior.