### PR TITLE
Add optional override_ttl field for ALIAS records

### DIFF
--- a/nsone/rest/records.py
+++ b/nsone/rest/records.py
@@ -17,7 +17,7 @@ class Records(resource.BaseResource):
     ROOT = 'zones'
 
     INT_FIELDS = ['ttl']
-    BOOL_FIELDS = ['use_csubnet']
+    BOOL_FIELDS = ['use_csubnet', 'override_ttl']
     PASSTHRU_FIELDS = ['networks', 'meta', 'regions', 'link']
 
     # answers must be:


### PR DESCRIPTION
This adds support for an optional field `override_ttl` which can be set on
ALIAS records to force them to override the TTL of the target record and
use the TTL of the ALIAS record itself.