### PR TITLE
Adds transport specific gathering of rate limit fields in resp headers.

### DIFF
--- a/nsone/rest/errors.py
+++ b/nsone/rest/errors.py
@@ -48,13 +48,14 @@ class AuthException(ResourceException):
 
 class RateLimitException(ResourceException):
 
-    def __init__(self, message, response=None, body=None):
+    def __init__(self, message, response=None, body=None, 
+                 by=None, limit=None, remaining=None, period=None):
         ResourceException.__init__(self, message, response, body)
-        hdrs = response.headers._rawHeaders
-        self.by = hdrs['x-ratelimit-by'][0]
-        self.limit = hdrs['x-ratelimit-limit'][0]
-        self.period = hdrs['x-ratelimit-period'][0]
+        self.by = by
+        self.limit = limit
+        self.period = period
+        self.remaining = remaining
 
     def __repr__(self):
-        return '<RateLimitException by=%s limit=%s period=%s>' % \
-               (self.by, self.limit, self.period)
+        return '<RateLimitException by=%s limit=%s period=%s remaining=%s>' % \
+               (self.by, self.limit, self.period, self.remaining)

--- a/nsone/rest/transport/requests.py
+++ b/nsone/rest/transport/requests.py
@@ -43,9 +43,13 @@ class RequestsTransport(TransportBase):
                 return
             else:
                 if resp.status_code == 429:
-                    raise RateLimitException('rate limit exceeded',
-                                             resp,
-                                             resp.text)
+                    raise RateLimitException(
+                        'rate limit exceeded', resp, resp.text, 
+                        by=resp.headers.get('X-RateLimit-By', 'customer'), 
+                        limit=resp.headers.get('X-RateLimit-Limit', 10),
+                        period=resp.headers.get('X-RateLimit-Period', 1), 
+                        remaining=resp.headers.get('X-RateLimit-Remaining', 100)
+                    )
                 elif resp.status_code == 401:
                     raise AuthException('unauthorized',
                                         resp,

--- a/nsone/rest/transport/twisted.py
+++ b/nsone/rest/transport/twisted.py
@@ -109,9 +109,13 @@ class TwistedTransport(TransportBase):
                                          data))
         if response.code != 200:
             if response.code == 429:
-                raise RateLimitException('rate limit exceeded',
-                                         response,
-                                         body)
+                raise RateLimitException(
+                    'rate limit exceeded', response, body,
+                    by=response.headers.getRawHeaders('x-ratelimit-by', ['customer'])[0],
+                    limit=response.headers.getRawHeaders('x-ratelimit-limit', [10])[0],
+                    period=response.headers.getRawHeaders('x-ratelimit-period', [1])[0],
+                    remaining=response.headers.getRawHeaders('x-ratelimit-remaining', [100])[0]
+                )
             elif response.code == 401:
                 raise AuthException('unauthorized',
                                     response,


### PR DESCRIPTION
Each transport(basic/requests/twisted) is responsible for parsing http response "rate limiting" headers and passing them to the `nsone.rest.errors.RateLimitException` upon construction.

Also adds ability to ignore ssl in basic transport.


