### PR TITLE
Handle zone determination for apex records correctly

### DIFF
--- a/nsone/__init__.py
+++ b/nsone/__init__.py
@@ -159,7 +159,7 @@ class NSONE:
             if len(parts) <= 2:
                 zone = '.'.join(parts)
             else:
-                zone = '.'.join(domain.split('.')[1:])
+                zone = '.'.join(parts[1:])
         z = nsone.zones.Zone(self.config, zone)
         return z.loadRecord(domain, type, callback=callback, errback=errback,
                             **kwargs)

--- a/nsone/__init__.py
+++ b/nsone/__init__.py
@@ -155,7 +155,11 @@ class NSONE:
         import nsone.zones
         if zone is None:
             # extract from record string
-            zone = '.'.join(domain.split('.')[1:])
+            parts = domain.split('.')
+            if len(parts) <= 2:
+                zone = '.'.join(parts)
+            else:
+                zone = '.'.join(domain.split('.')[1:])
         z = nsone.zones.Zone(self.config, zone)
         return z.loadRecord(domain, type, callback=callback, errback=errback,
                             **kwargs)


### PR DESCRIPTION
Previously to guess the zone when not specified explicitly in calls to loadRecord() we were just chopping off the leftmost label. This isn't always going to be correct, but it was obviously incorrect in the case of apex records (chopping the leftmost label off of example.com leaves you with just com), so this fixes how we handle at least the most common subset of those.